### PR TITLE
Implement new_edits flag on bulk updates

### DIFF
--- a/src/Normalizer/BulkDocsNormalizer.php
+++ b/src/Normalizer/BulkDocsNormalizer.php
@@ -33,6 +33,9 @@ class BulkDocsNormalizer extends ContentEntityNormalizer {
    */
   public function denormalize($data, $class, $format = NULL, array $context = array()) {
     $result = array();
+    if (isset($data['new_edits']) && ($data['new_edits']) === FALSE) {
+      $context['new_edits'] = FALSE;
+    }
     if (is_array($data) && isset($data['docs'])) {
       foreach ($data['docs'] as $field) {
         $result['docs'][] = parent::denormalize($field, $class, $format, $context);

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -156,7 +156,7 @@ class ContentEntityNormalizer extends NormalizerBase implements DenormalizerInte
     }
     else {
       /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
-      $storage->create($data);
+      $entity = $storage->create($data);
     }
 
     if ($entity_id) {

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -164,6 +164,11 @@ class ContentEntityNormalizer extends NormalizerBase implements DenormalizerInte
       $entity->enforceIsNew(FALSE);
       $entity->setNewRevision(FALSE);
     }
+
+    if (isset($context['new_edits']) && ($context['new_edits'] === FALSE)) {
+      $entity->new_edits = FALSE;
+    }
+
     return $entity;
   }
 }

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -148,6 +148,7 @@ class ContentEntityNormalizer extends NormalizerBase implements DenormalizerInte
     $storage = $this->entityManager->getStorage($entity_type_id);
 
     if ($entity_id) {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
       $entity = $storage->load($entity_id) ?: $storage->loadDeleted($entity_id);
       foreach ($data as $name => $value) {
         $entity->$name = $value;

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -145,8 +145,20 @@ class ContentEntityNormalizer extends NormalizerBase implements DenormalizerInte
       }
     }
 
-    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
-    $entity = $this->entityManager->getStorage($entity_type_id)->create($data);
+    if ($entity_id) {
+      $entity = $this->entityManager->getStorage($entity_type_id)->load($entity_id);
+      if (!$entity) {
+        $entity = $this->entityManager->getStorage($entity_type_id)->loadDeleted($entity_id);
+      }
+      foreach ($data as $name => $value) {
+        $entity->$name = $value;
+      }
+    }
+    else {
+      /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+      $entity = $this->entityManager->getStorage($entity_type_id)
+        ->create($data);
+    }
 
     if ($entity_id) {
       $entity->enforceIsNew(FALSE);

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -145,19 +145,17 @@ class ContentEntityNormalizer extends NormalizerBase implements DenormalizerInte
       }
     }
 
+    $storage = $this->entityManager->getStorage($entity_type_id);
+
     if ($entity_id) {
-      $entity = $this->entityManager->getStorage($entity_type_id)->load($entity_id);
-      if (!$entity) {
-        $entity = $this->entityManager->getStorage($entity_type_id)->loadDeleted($entity_id);
-      }
+      $entity = $storage->load($entity_id) ?: $storage->loadDeleted($entity_id);
       foreach ($data as $name => $value) {
         $entity->$name = $value;
       }
     }
     else {
       /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
-      $entity = $this->entityManager->getStorage($entity_type_id)
-        ->create($data);
+      $storage->create($data);
     }
 
     if ($entity_id) {

--- a/src/Normalizer/ContentEntityNormalizer.php
+++ b/src/Normalizer/ContentEntityNormalizer.php
@@ -151,7 +151,7 @@ class ContentEntityNormalizer extends NormalizerBase implements DenormalizerInte
       /** @var \Drupal\Core\Entity\ContentEntityInterface $entity */
       $entity = $storage->load($entity_id) ?: $storage->loadDeleted($entity_id);
       foreach ($data as $name => $value) {
-        $entity->$name = $value;
+        $entity->{$name} = $value;
       }
     }
     else {

--- a/src/Tests/BulkDocsResourceTest.php
+++ b/src/Tests/BulkDocsResourceTest.php
@@ -101,6 +101,41 @@ class BulkDocsResourceTest extends ResourceTestBase {
         $this->assertEqual($entity->_revs_info->count(), 2, "Entity number $entity_number has two revisions.");
       }
     }
+
+    $entities = $this->createTestEntities($entity_type, TRUE);
+    // @todo The below code is copied from above and should probably be in a method
+    foreach ($entities as $key => $entity) {
+      $patched_entities['docs'][$key] = entity_load($entity_type, $entity->id(), TRUE);
+      $patched_entities['docs'][$key]->set(
+        'field_test_text',
+        array(
+          0 => array(
+            'value' => $this->randomString(),
+            'format' => 'plain_text',
+          )
+        )
+      );
+      if ($key == 1) {
+        // Delete an entity.
+        $patched_entities['docs'][$key]->delete();
+      }
+    }
+
+    $patched_entities['new_edits'] = FALSE;
+    $serialized = $serializer->serialize($patched_entities, $this->defaultFormat);
+    $response = $this->httpRequest("$db/_bulk_docs", 'POST', $serialized);
+    $this->assertResponse('201', 'HTTP response code is correct when entities are updated.');
+    $data = Json::decode($response);
+    $this->assertTrue(is_array($data), 'Data format is correct.');
+
+    foreach ($data as $key => $entity_info) {
+      $entity_number = $key+1;
+      $this->assertTrue(isset($entity_info['rev']), "POST request returned a revision hash for entity number $entity_number.");
+      $new_rev = $entity_info['rev'];
+      $old_rev = $patched_entities['docs'][$key]->_revs_info->get(0)->rev;
+      $this->assertEqual($new_rev, $old_rev, "POST request returned unchanged revision ID for entity number $entity_number.");
+    }
+
   }
 
   /**

--- a/src/Tests/BulkDocsResourceTest.php
+++ b/src/Tests/BulkDocsResourceTest.php
@@ -94,8 +94,8 @@ class BulkDocsResourceTest extends ResourceTestBase {
       }
       else {
         $this->assertEqual(
-          $entity->get('field_test_text'),
-          $patched_entity->get('field_test_text'),
+          $entity->get('field_test_text')->value,
+          $patched_entity->get('field_test_text')->value,
           "Correct value for 'field_test_text' for entity number $entity_number."
         );
         $this->assertEqual($entity->_revs_info->count(), 2, "Entity number $entity_number has two revisions.");

--- a/src/Tests/BulkDocsResourceTest.php
+++ b/src/Tests/BulkDocsResourceTest.php
@@ -88,7 +88,7 @@ class BulkDocsResourceTest extends ResourceTestBase {
 
     foreach ($patched_entities['docs'] as $key => $patched_entity) {
       $entity_number = $key+1;
-      $entity = entity_load($entity_type, $patched_entity->id());
+      $entity = entity_load($entity_type, $patched_entity->id(), TRUE);
       if ($key == 1) {
         $this->assertEqual($entity, NULL, "Entity number $entity_number has been deleted.");
       }

--- a/src/Tests/BulkDocsResourceTest.php
+++ b/src/Tests/BulkDocsResourceTest.php
@@ -98,6 +98,7 @@ class BulkDocsResourceTest extends ResourceTestBase {
           $patched_entity->get('field_test_text'),
           "Correct value for 'field_test_text' for entity number $entity_number."
         );
+        $this->assertEqual($entity->_revs_info->count(), 2, "Entity number $entity_number has two revisions.");
       }
     }
   }


### PR DESCRIPTION
Will include further commits to implement new_edits flag - at the moment just has a failing test for revision IDs on bulk doc updates.
