### PR TITLE
Fix error on module uninstall.

### DIFF
--- a/relaxed.install
+++ b/relaxed.install
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Implements hook_install().
  */
@@ -10,4 +11,21 @@ function relaxed_install() {
   $rest_config = \Drupal::configFactory()->getEditable('rest.settings');
   $rest_resource_config = $rest_config->get('resources');
   $rest_config->set('resources', array_merge($rest_resource_config, $relaxed_resource_config))->save();
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function relaxed_uninstall() {
+  // Remove 'resource' settings defined by relaxed module from 'resource'
+  // settings define by rest module.
+  $relaxed_resource_config = \Drupal::config('relaxed.settings')->get('resources');
+  $rest_config = \Drupal::configFactory()->getEditable('rest.settings');
+  $rest_resource_config = $rest_config->get('resources');
+  foreach ($relaxed_resource_config as $key => $item) {
+    if (isset($rest_resource_config[$key])) {
+      unset($rest_resource_config[$key]);
+    }
+  }
+  $rest_config->set('resources', $rest_resource_config)->save();
 }

--- a/relaxed.install
+++ b/relaxed.install
@@ -17,8 +17,8 @@ function relaxed_install() {
  * Implements hook_uninstall().
  */
 function relaxed_uninstall() {
-  // Remove 'resource' settings defined by relaxed module from 'resource'
-  // settings define by rest module.
+  // Remove 'resource' settings defined by RELAXed Web Services module from
+  // 'resource' settings defined by RESTful Web Services module.
   $relaxed_resource_config = \Drupal::config('relaxed.settings')->get('resources');
   $rest_config = \Drupal::configFactory()->getEditable('rest.settings');
   $rest_resource_config = $rest_config->get('resources');

--- a/src/Tests/UninstallTest.php
+++ b/src/Tests/UninstallTest.php
@@ -39,9 +39,7 @@ class UninstallTest extends ModuleTestBase {
     $relaxed_config = \Drupal::config('relaxed.settings')->get('resources');
     $rest_config = \Drupal::config('rest.settings')->get('resources');
     foreach ($relaxed_config as $key => $item) {
-      if (isset($rest_config[$key])) {
-        $this->pass("Relaxed module configuration ($key) found in Rest module configuration.");
-      }
+      $this->assertTrue(isset($rest_config[$key]), "Relaxed module configuration ($key) found in Rest module configuration.");
     }
     // Only uninstall Relaxed.
     $this->moduleInstaller->uninstall(['relaxed']);
@@ -49,9 +47,7 @@ class UninstallTest extends ModuleTestBase {
     $this->assertModules(['relaxed'], FALSE);
     $this->assertNoModuleConfig('relaxed');
     foreach ($relaxed_config as $key => $item) {
-      if (isset($rest_config[$key])) {
-        $this->fail("Relaxed module configuration ($key) found in Rest module configuration.");
-      }
+      $this->assertTrue(!isset($rest_config[$key]), "Relaxed module configuration ($key) not found in Rest module configuration.");
     }
   }
 

--- a/src/Tests/UninstallTest.php
+++ b/src/Tests/UninstallTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\relaxed\Tests\UninstallTest.
+ */
+
+namespace Drupal\relaxed\Tests;
+
+use Drupal\system\Tests\Module\ModuleTestBase;
+
+/**
+ * Tests install/uninstall relaxed module.
+ *
+ * @group relaxed
+ */
+class UninstallTest extends ModuleTestBase {
+
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * @var \Drupal\Core\Extension\ModuleInstallerInterface
+   */
+  protected $moduleInstaller;
+
+  public function setUp() {
+    parent::setUp();
+    $this->moduleInstaller = $this->container->get('module_installer');
+  }
+
+  /**
+   * Tests that relaxed module can be uninstalled properly.
+   */
+  public function testInstallUninstall() {
+    $modules = ['multiversion', 'relaxed'];
+    $this->moduleInstaller->install($modules);
+    $this->assertModules($modules, TRUE);
+    $this->assertModuleConfig('relaxed');
+    $relaxed_config = \Drupal::config('relaxed.settings')->get('resources');
+    $rest_config = \Drupal::config('rest.settings')->get('resources');
+    foreach ($relaxed_config as $key => $item) {
+      if (isset($rest_config[$key])) {
+        $this->pass("Relaxed module configuration ($key) found in Rest module configuration.");
+      }
+    }
+    // Only uninstall Relaxed.
+    $this->moduleInstaller->uninstall(['relaxed']);
+    $rest_config = \Drupal::config('rest.settings')->get('resources');
+    $this->assertModules(['relaxed'], FALSE);
+    $this->assertNoModuleConfig('relaxed');
+    foreach ($relaxed_config as $key => $item) {
+      if (isset($rest_config[$key])) {
+        $this->fail("Relaxed module configuration ($key) found in Rest module configuration.");
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This fixes the errors when uninstalling the module. Errors are caused by missing `relaxed:*` plugins (when we uninstall the module these plugins are missing but the information about them is still stored in `rest.settings` configuration).
This will remove information about `relaxed` plugins from `rest.settings` on module uninstall.
