### PR TITLE
Replication log fixes

### DIFF
--- a/relaxed.services.yml
+++ b/relaxed.services.yml
@@ -12,6 +12,11 @@ services:
     arguments: ['@entity.manager', '@entity.index.uuid', '@entity.index.rev.tree', '@rest.link_manager']
     tags:
       - { name: normalizer, priority: 10 }
+  relaxed.normalizer.replication_log:
+    class: Drupal\relaxed\Normalizer\ReplicationLogNormalizer
+    arguments: ['@entity.manager', '@entity.index.uuid', '@entity.index.rev.tree', '@rest.link_manager']
+    tags:
+      - { name: normalizer, priority: 20 }
   relaxed.normalizer.bulk_docs:
     class: Drupal\relaxed\Normalizer\BulkDocsNormalizer
     tags:

--- a/src/Controller/ResourceController.php
+++ b/src/Controller/ResourceController.php
@@ -131,6 +131,7 @@ class ResourceController implements ContainerAwareInterface {
       $data = array('error' => $error, 'reason' => $reason);
       $content = $this->serializer()->serialize($data, $format);
     }
+    watchdog_exception('multiversion', $e);
     return new Response($content, $status, $headers);
   }
 

--- a/src/Normalizer/ReplicationLogNormalizer.php
+++ b/src/Normalizer/ReplicationLogNormalizer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\relaxed\Normalizer;
+
+class ReplicationLogNormalizer extends ContentEntityNormalizer {
+
+  /**
+   * @var string[]
+   */
+  protected $supportedInterfaceOrClass = array('Drupal\relaxed\Entity\ReplicationLogInterface');
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($entity, $format = NULL, array $context = array()) {
+    $data = parent::normalize($entity, $format, $context);
+
+    // Flatten some properties to follow the spec.
+    foreach (['session_id', 'source_last_seq'] as $field_name) {
+      if (isset($data[$field_name][0]['value'])) {
+        $data[$field_name] = $data[$field_name][0]['value'];
+      }
+    }
+
+    return $data;
+  }
+
+}

--- a/src/Normalizer/ReplicationLogNormalizer.php
+++ b/src/Normalizer/ReplicationLogNormalizer.php
@@ -15,10 +15,14 @@ class ReplicationLogNormalizer extends ContentEntityNormalizer {
   public function normalize($entity, $format = NULL, array $context = array()) {
     $data = parent::normalize($entity, $format, $context);
 
-    // Flatten some properties to follow the spec.
+    // Flatten some properties to follow the spec and make sure we have a NULL
+    // value if there's no other value available.
     foreach (['session_id', 'source_last_seq'] as $field_name) {
-      if (isset($data[$field_name][0]['value'])) {
+      if (!empty($data[$field_name][0]['value'])) {
         $data[$field_name] = $data[$field_name][0]['value'];
+      }
+      else {
+        $data[$field_name] = NULL;
       }
     }
 

--- a/src/Tests/Normalizer/ReplicationLogNormalizerTest.php
+++ b/src/Tests/Normalizer/ReplicationLogNormalizerTest.php
@@ -48,6 +48,10 @@ class ReplicationLogNormalizerTest extends NormalizerTestBase {
       $this->assertEqual($expected[$field_name], $normalized[$field_name], "Field $field_name is normalized correctly.");
     }
     $this->assertEqual(array_diff_key($normalized, $expected), array(), 'No unexpected data is added to the normalized array.');
+
+    $entity = ReplicationLog::create();
+    $normalized = $this->serializer->normalize($entity);
+    $this->assertIdentical(NULL, $normalized['source_last_seq'], "Field is normalized correctly when emtpy.");
   }
 
   public function testDenormalize() {

--- a/src/Tests/Normalizer/ReplicationLogNormalizerTest.php
+++ b/src/Tests/Normalizer/ReplicationLogNormalizerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\relaxed\Tests\Normalizer\ReplicationLogNormalizerTest.
+ */
+
+namespace Drupal\relaxed\Tests\Normalizer;
+use Drupal\relaxed\Entity\ReplicationLog;
+
+/**
+ * Tests the replication_log serialization format.
+ *
+ * @group relaxed
+ */
+class ReplicationLogNormalizerTest extends NormalizerTestBase {
+
+  public static $modules = array('serialization', 'system', 'field', 'entity_test', 'text', 'filter', 'user', 'key_value', 'multiversion', 'rest', 'relaxed');
+
+  protected $entityClass = 'Drupal\relaxed\Entity\ReplicationLog';
+
+  protected function setUp() {
+    parent::setUp();
+
+    $this->entity = ReplicationLog::create(['source_last_seq' => 99]);
+  }
+
+  public function testNormalize() {
+    $expected = [
+      '@context' => array(
+        '_id' => '@id',
+        'replication_log' => \Drupal::service('rest.link_manager')->getTypeUri(
+          'replication_log',
+          $this->entity->bundle()
+        ),
+      ),
+      '@type' => 'replication_log',
+      '_id' => $this->entity->uuid(),
+      '_rev' => '0-00000000000000000000000000000000',
+      'history' => [],
+      'session_id' => $this->entity->getSessionId(),
+      'source_last_seq' => $this->entity->getSourceLastSeq(),
+    ];
+
+    $normalized = $this->serializer->normalize($this->entity);
+
+    foreach (array_keys($expected) as $field_name) {
+      $this->assertEqual($expected[$field_name], $normalized[$field_name], "Field $field_name is normalized correctly.");
+    }
+    $this->assertEqual(array_diff_key($normalized, $expected), array(), 'No unexpected data is added to the normalized array.');
+  }
+
+  public function testDenormalize() {
+    $normalized = $this->serializer->normalize($this->entity);
+    $denormalized = $this->serializer->denormalize($normalized, $this->entityClass, 'json');
+    $this->assertTrue($denormalized instanceof $this->entityClass, 'Denormalized entity is an instance of ' . $this->entityClass);
+    $this->assertIdentical($denormalized->getEntityTypeId(), $this->entity->getEntityTypeId(), 'Expected entity type found.');
+
+    $this->assertTrue(!empty($denormalized->session_id->value), 'session_id denormalized correctly.');
+    $this->assertTrue(!empty($denormalized->source_last_seq->value), 'source_last_seq denormalized correctly.');
+  }
+
+}

--- a/tests/bin/pouchdb.sh
+++ b/tests/bin/pouchdb.sh
@@ -7,7 +7,7 @@ npm install -g mocha-phantomjs
 npm install chai
 npm install es5-shim
 npm install mocha
-npm install pouchdb
+npm install pouchdb@"~4.0"
 
 mv $TRAVIS_BUILD_DIR/../drupal/core/modules/system/tests/modules/entity_test $TRAVIS_BUILD_DIR/../drupal/modules/entity_test
 mv $TRAVIS_BUILD_DIR/../drupal/modules/relaxed/tests/pouchdb/test.html $TRAVIS_BUILD_DIR/../drupal/test.html

--- a/tests/bin/pouchdb.sh
+++ b/tests/bin/pouchdb.sh
@@ -19,4 +19,8 @@ drush en --yes entity_test, relaxed_test || true
 
 mocha-phantomjs -s localToRemoteUrlAccessEnabled=true -s webSecurityEnabled=false test.html | tee /tmp/output.txt
 
+#-----------------------------------
+sudo cat /var/log/apache2/error.log
+#-----------------------------------
+
 test 1 -eq $(egrep -c "(2 passing)" /tmp/output.txt)

--- a/tests/pouchdb/test.js
+++ b/tests/pouchdb/test.js
@@ -11,7 +11,7 @@ var docs = [
 ];
 
 // Enable debugging mode.
-//PouchDB.debug.enable('*');
+PouchDB.debug.enable('*');
 //PouchDB.debug.enable('pouchdb:api');
 //PouchDB.debug.enable('pouchdb:http');
 


### PR DESCRIPTION
When running a replication more than once `session_id` and `source_last_seq` gets messed up in the serialization of the replication log entity, causing the replicator to fail horribly.

This PR includes a dedicated class for normalizing the ReplicationLog entity, and hacks in ContentEntityNormalizer for denormalization (because we don't have a good way of separating denormalization at the moment).
