### PR TITLE
Allow for the ChangesResource to be consumed in chunks

### DIFF
--- a/src/Plugin/rest/resource/ChangesResource.php
+++ b/src/Plugin/rest/resource/ChangesResource.php
@@ -77,7 +77,7 @@ class ChangesResource extends ResourceBase {
       $changes->includeDocs(TRUE);
     }
 
-    return new ResourceResponse($changes, 200);
+    return new ResourceResponse($changes, 200, ['Content-Length' => strlen(\Drupal::service('serializer')->serialize($changes, 'json'))]);
   }
 
 }


### PR DESCRIPTION
This is a quick proposal for many people may be facing the same problem like me [in this thread](https://www.drupal.org/node/2770483). With this change CouchDB's SocketClient can chunk the JSON data instead of returning an empty response body.
