### PR TITLE
New format compatibility

### DIFF
--- a/src/Controller/ResourceController.php
+++ b/src/Controller/ResourceController.php
@@ -265,7 +265,9 @@ class ResourceController implements ContainerInjectionInterface {
     // If an acceptable format is requested, then use that. Otherwise, including
     // and particularly when the client forgot to specify a format, then use
     // heuristics to select the format that is most likely expected.
-    if (empty($acceptable_formats)|| in_array($requested_format, $acceptable_formats)) {
+    // Special case mixed here. We can't use this as a response format for
+    // serialization.
+    if (!in_array($requested_format, ['mixed', 'related'], TRUE) && (empty($acceptable_formats) || in_array($requested_format, $acceptable_formats))) {
       return $requested_format;
     }
     // If a request body is present, then use the format corresponding to the

--- a/src/Controller/ResourceController.php
+++ b/src/Controller/ResourceController.php
@@ -243,7 +243,7 @@ class ResourceController implements ContainerInjectionInterface {
   protected function getResponseFormat(Route $route, Request $request, ApiResourceInterface $api_resource) {
     $api_resource_formats = $api_resource->getAllowedFormats();
 
-    $acceptable_response_formats = $this->getAcceptableResponseFormatsFromRequest($request);
+    $acceptable_response_formats = $this->getAcceptableResponseFormatsFromRequestHeaders($request);
     $acceptable_route_response_formats = $route->hasRequirement('_format') ? explode('|', $route->getRequirement('_format')) : [];
 
     if ($acceptable_response_formats) {
@@ -265,7 +265,7 @@ class ResourceController implements ContainerInjectionInterface {
     // If an acceptable format is requested, then use that. Otherwise, including
     // and particularly when the client forgot to specify a format, then use
     // heuristics to select the format that is most likely expected.
-    if (in_array($requested_format, $acceptable_formats)) {
+    if (empty($acceptable_formats)|| in_array($requested_format, $acceptable_formats)) {
       return $requested_format;
     }
     // If a request body is present, then use the format corresponding to the
@@ -333,7 +333,7 @@ class ResourceController implements ContainerInjectionInterface {
    *
    * @return array
    */
-  protected function getAcceptableResponseFormatsFromRequest(Request $request) {
+  protected function getAcceptableResponseFormatsFromRequestHeaders(Request $request) {
     $acceptable_content_types = array_keys(AcceptHeader::fromString($request->headers->get('X-Relaxed-Document-Accept'))->all());
 
     return array_unique(array_filter(array_map(function ($content_type) use ($request) {

--- a/src/HttpMultipart/HttpFoundation/MultipartResponse.php
+++ b/src/HttpMultipart/HttpFoundation/MultipartResponse.php
@@ -20,7 +20,7 @@ class MultipartResponse extends ApiResourceResponse {
   /**
    * @var Response[]
    */
-  protected $parts;
+  protected $parts = [];
 
   /**
    * Constructor.
@@ -28,30 +28,38 @@ class MultipartResponse extends ApiResourceResponse {
   public function __construct(array $parts = NULL, $status = 200, $headers = [], $subtype = NULL) {
     parent::__construct(NULL, $status, $headers);
 
+    if ($parts) {
+      $this->setParts($parts);
+    }
+
     $this->subtype = $subtype ?: 'mixed';
     $this->boundary = md5(microtime());
-
-    if (NULL !== $parts) {
-      $this->setParts($parts);
-      $content = '';
-      foreach ($this->getParts() as $part) {
-        $content .= "--{$this->boundary}\r\n";
-        $content .= "Content-Type: {$part->headers->get('Content-Type')}\r\n\r\n";
-        $content .= \Drupal::service('replication.serializer')
-          ->serialize($part->getResponseData(), 'json');
-        $content .= "\r\n";
-      }
-      $content .= "--{$this->boundary}--";
-      $this->setContent($content);
-    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function prepare(Request $request) {
-    $this->headers->set('Content-Type', "multipart/{$this->subtype}; boundary=\"{$this->boundary}\"");
+    $this->headers->set('Content-Type', sprintf('multipart/%s; boundary="%s"', $this->subtype, $this->boundary));
     $this->headers->set('Transfer-Encoding', 'chunked');
+
+    // Prepare the response content from the parts.
+    $parts = $this->getParts();
+
+    if ($parts) {
+      $content = '';
+
+      foreach ($this->getParts() as $part) {
+        $content .= sprintf("--%s\r\n", $this->boundary);
+        $content .= sprintf("Content-Type: %s\r\n\r\n", $part->headers->get('Content-Type'));
+        $content .= $part->getContent();
+        $content .= "\r\n";
+      }
+
+      $content .= sprintf("--%s--", $this->boundary);
+
+      $this->setContent($content);
+    }
 
     return parent::prepare($request);
   }


### PR DESCRIPTION
This does a couple of things:

- Modifies the `MultipartResponse` class to create the multipart content body for the response in `prepare` instead of in construct. We are already serializing the content for each part of the response in the `ResourceController` so we were in effect doing it twice :) That's quite a bit of additional overhead if you have a few documents. I also needed to rely on this, so I could set the serialized content outside of this class :)
- Introduces checking for a content accept header to negotiate the format used in the document responses. We can then negotiate this and select the appropriate FormatNegotiator plugin. The only catch is that I have had to use an `X-Relaxed-Document-Accept` header instead of the standard `Accept` header - as the CouchDbClient overwrites this header itself. The alternative is to check if this is already set first, in the places it's being done, and allow us to use our custom accept. Might be a better way to go (although this goes against the initial default header work I did, in that passing it in per request __should__ override the defaults).