### PR TITLE
Move response content preparation to ::prepare instead of __construct

### DIFF
--- a/src/HttpMultipart/ResourceMultipartResponse.php
+++ b/src/HttpMultipart/ResourceMultipartResponse.php
@@ -26,24 +26,10 @@ class ResourceMultipartResponse extends MultipartResponse {
   public function sendContent() {
     // This fixes the "Malformed encoding found in chunked-encoding"
     // error message in curl and makes possible to get the correct response body.
-    $size = $this->getSize();
+    $size = strlen($this->getContent());
     echo "$size\r\n";
-    parent::sendContent();
-  }
 
-  /**
-   * Returns the length of all the parts in the response body.
-   *
-   * @return int
-   */
-  protected function getSize() {
-    $size = 0;
-    foreach ($this->parts as $part) {
-      $content = $part->getContent();
-      $output = "--{$this->boundary}" . "{$part->headers}" . $content;
-      $size += strlen($output);
-    }
-    return $size;
+    parent::sendContent();
   }
 
 }


### PR DESCRIPTION
This is the 8.x-1.x version of https://github.com/relaxedws/drupal-relaxed/pull/89/commits/33bd808929369099bae316ff4bfdb43a3e295bd9