### PR TITLE
Allow workspace context to be available for all requests, not just POST/PUT

### DIFF
--- a/src/Controller/ResourceController.php
+++ b/src/Controller/ResourceController.php
@@ -122,21 +122,21 @@ class ResourceController implements ContainerInjectionInterface {
       'api_resource_id' => $api_resource_id,
     ];
 
+    // If we have a workspace parameter, pass it to the serializer for
+    // denormalization.
+    foreach ($parameters as $parameter) {
+      if ($parameter instanceof WorkspaceInterface) {
+        $context['workspace'] = $parameter;
+        break;
+      }
+    }
+
     $entity = NULL;
     $definition = $api_resource->getPluginDefinition();
 
     if (!empty($content)) {
       try {
         $class = isset($definition['serialization_class'][$method]) ? $definition['serialization_class'][$method] : $definition['serialization_class']['canonical'];
-
-        // If we have a workspace parameter, pass it to the serializer for denormalization.
-        foreach ($parameters as $parameter) {
-          if ($parameter instanceof WorkspaceInterface) {
-            $context['workspace'] = $parameter;
-            break;
-          }
-        }
-
         $entity = $serializer->deserialize($content, $class, $content_type_format, $context);
       }
       catch (\Exception $e) {


### PR DESCRIPTION
For some custom integration work I'm doing with relaxed, I need the workspace context in my normalizer, this is just related to retrieving documents. Not a POST/PUT request. Currently, we rely on that as we only add the 'workspace' context when we check the request body and deserialize it. This just makes it available for all requests going through the relaxed `ResourceController`.